### PR TITLE
一般ユーザー新規登録画面を追加

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,5 +1,6 @@
 class Admin::UsersController < ApplicationController
-  before_action :require_admin
+  skip_before_action :login_required
+  # before_action :require_admin
   def new
     @user = User.new
   end
@@ -8,7 +9,8 @@ class Admin::UsersController < ApplicationController
     @user = User.new(user_params)
 
     if@user.save
-      redirect_to admin_user_url(@user), notice: "ユーザー 「#{@user.name}」を登録しました"
+      # redirect_to admin_user_url(@user), notice: "ユーザー 「#{@user.name}」を登録しました"
+      redirect_to login_url, notice: "ユーザー 「#{@user.name}」を登録しました"
     else
       render :new
     end

--- a/app/views/admin/users/_form.html.slim
+++ b/app/views/admin/users/_form.html.slim
@@ -5,15 +5,16 @@
 
 = form_with model: [:admin, @user], local: true do |f|
   .form-group
-    = f.label :name, '名前'
+    = f.label :name, 'お名前(保護者)'
     = f.text_field :name, class: 'form-control'
   .form-group
     = f.label :email, 'メールアドレス'
     = f.text_field :email, class: 'form-control'
-  .form-check
-    = f.label :admin, class: 'form-check-label'
-      = f.check_box :admin, class: 'form-check-input'
-      | 管理者権限
+  - if current_user
+    .form-check
+      = f.label :admin, class: 'form-check-label'
+        = f.check_box :admin, class: 'form-check-input'
+        | 管理者権限
   .form-group
     = f.label :password, 'パスワード'
     = f.password_field :password, class: 'form-control'

--- a/app/views/admin/users/new.html.slim
+++ b/app/views/admin/users/new.html.slim
@@ -1,6 +1,7 @@
 h1 ユーザー登録
 
-.nav.justify-content-end
-  = link_to '一覧', admin_users_path, class: 'nav-link'
+- if current_user
+  .nav.justify-content-end
+    = link_to '一覧', admin_users_path, class: 'nav-link'
 
 = render partial: 'form', locals: { user: @user }

--- a/app/views/sessions/new.html.slim
+++ b/app/views/sessions/new.html.slim
@@ -7,4 +7,5 @@ h1 ログイン
   .form-group
     = f.label :password, 'パスワード'
     = f.password_field :password, class: 'form-control', id: 'session_password'
-  = f.submit 'ログインする', class: 'btn btn-primary'
+  = f.submit 'ログインする', class: 'btn btn-primary mb-3'
+= link_to '新規登録の方はこちらへ', new_admin_user_path, class: 'text-black-50'


### PR DESCRIPTION
管理者用の新規ユーザー画面を改造。
ログイン画面から新規登録の画面へ行けるようにした。
新規登録後のアクションをユーザーの一覧表示からログイン画面に向かうようにした。
**admin/userのログイン必須と管理者必須のbefore actionを消してしまっているので後で追加する必要がある**