### PR TITLE
ユーザー向けオーダー一覧にユーザー情報更新ボタンを付加

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,6 +1,6 @@
 class Admin::UsersController < ApplicationController
-  skip_before_action :login_required
-  # before_action :require_admin
+  skip_before_action :login_required, only: [:new, :create]
+  # before_action :require_admin, only: [:show, :edit, :update, :destroy]
   def new
     @user = User.new
   end
@@ -32,7 +32,8 @@ class Admin::UsersController < ApplicationController
     @user = User.find(params[:id])
 
     if @user.update(user_params)
-      redirect_to admin_user_url(@user), notice: "ユーザー「#{@user.name}」を更新しました。"
+      # redirect_to admin_user_url(@user), notice: "ユーザー「#{@user.name}」を更新しました。"
+      redirect_to orders_path, notice: "ユーザー「#{@user.name}」を更新しました。"
     else
       render :edit
     end
@@ -41,7 +42,8 @@ class Admin::UsersController < ApplicationController
   def destroy
     @user = User.find(params[:id])
     @user.destroy
-    redirect_to admin_users_url, notice: "ユーザー「#{@user.name}」を削除しました."
+    # redirect_to admin_users_url, notice: "ユーザー「#{@user.name}」を削除しました."
+    redirect_to orders_path, notice: "ユーザー「#{@user.name}」を削除しました."
   end
 
   private

--- a/app/views/orders/index.html.slim
+++ b/app/views/orders/index.html.slim
@@ -1,6 +1,7 @@
 h1 タスク一覧
 
 = link_to '新規登録', new_order_path, class: 'btn btn-primary'
+= link_to 'ユーザ情報更新', edit_admin_user_path(current_user.id), class: 'btn btn-primary'
 
 .mb-3
 table.table.table-hover


### PR DESCRIPTION
ユーザーコントローラーの管理者要件のbeforeactionを全廃。
ログイン要求のbeforeアクションをnewとcreateだけスキップ可能に変更